### PR TITLE
Added link of Angular Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ app/
 * Tooling (AoT/Webpack/etc)
 * Build process info (platforms)
 * Resources section
+   * [Angular Developer Roadmap](https://roadmap.sh/angular)
+   


### PR DESCRIPTION
Hi @toddmotto,

I came across your repository [angular-architecture](https://github.com/toddmotto/angular-architecture) and found it to be a valuable resource for Angular enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Angular Developer Roadmap"](https://roadmap.sh/angular). I took the initiative to submit a ["Pull Request"](https://github.com/toddmotto/angular-architecture/pull/2) adding it.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz